### PR TITLE
privacy team: Fix link to Emmas needinfo table by removing trailing space from Email

### DIFF
--- a/js/privacy.json
+++ b/js/privacy.json
@@ -1,7 +1,7 @@
 {
   "developers": {
     "Ben": "bvandersloot@mozilla.com",
-    "Emma": "emz@mozilla.com ",
+    "Emma": "emz@mozilla.com",
     "Dan": "dmehic@mozilla.com",
     "Tim": "tihuang@mozilla.com",
     "Manuel": "manuel@mozilla.com",


### PR DESCRIPTION
Sorry, just noticed after #7 merged clicking on links in the privacy team needinfo dashboard :see_no_evil: