### PR TITLE
Update and rename secinf.json to appsec.json

### DIFF
--- a/js/appsec.json
+++ b/js/appsec.json
@@ -9,6 +9,8 @@
     "Tyson Smith": "twsmith@mozilla.com",
     "Jesse Schwartzentruber": "jschwartzentruber@mozilla.com",
     "Jason Kratzer": "jkratzer@mozilla.com",
-    "Simon Friedberger": "sfriedberger@mozilla.com"
+    "Simon Friedberger": "sfriedberger@mozilla.com",
+    "Maurice Dauer": "mdauer@mozilla.com",
+    "Fatih Kilic": "fkilic@mozilla.com"
   }
 }


### PR DESCRIPTION
We renamed the team to Firefox Application Security. Also, there were two interns missing from the list :)