### PR TITLE
Move api_key from a URL query parameter to a header

### DIFF
--- a/js/details.js
+++ b/js/details.js
@@ -83,9 +83,6 @@ function main(json) {
   // v2=needinfo?
 
   let url = NeedInfoConfig.bugzilla_search_url;
-  if (NeedInfoConfig.api_key.length > 0) {
-    url += "api_key=" + NeedInfoConfig.api_key + "&";
-  }
   url += NeedInfoConfig.bugs_query.replace("{id}", id);
 
   url += getBugzillaMaxDateQuery();
@@ -201,6 +198,7 @@ function retrieveInfoFor(url, userQuery)
 {
   $.ajax({
     url: url,
+    headers: {"X-Bugzilla-api-key": `${NeedInfoConfig.api_key}`},
     success: function (data) {
       populateBugs(url, userQuery, data);
       sortByDefault();
@@ -634,6 +632,7 @@ function submitCommand(url, bugId, jsonData) {
   console.log("submitting changes to bugzilla:", bugId);
   $.ajax({
     url: url,
+    headers: {"X-Bugzilla-api-key": `${NeedInfoConfig.api_key}`},
     type: 'PUT',
     data: jsonData,
     contentType: "application/json",
@@ -781,9 +780,6 @@ function queueBugChange(type, bugId, comment, to) {
 
   let json = JSON.stringify(data);
   let url = NeedInfoConfig.bugzilla_put_url.replace('{id}', bug.bugid);
-  if (NeedInfoConfig.api_key.length) {
-    url += "?api_key=" + NeedInfoConfig.api_key;
-  }
 
   submitCommand(url, bugId, json);
 }
@@ -945,12 +941,10 @@ function invokeRedirectTo() {
 function submitUserSearch(value) {
   let url = NeedInfoConfig.bugzilla_user_url;
   url = url.replace('{value}', value);
-  if (NeedInfoConfig.api_key.length) {
-    url += "&api_key=" + NeedInfoConfig.api_key;
-  }
   $('#autofill-user-search').empty();
   $.ajax({
     url: url,
+    headers: {"X-Bugzilla-api-key": `${NeedInfoConfig.api_key}`},
     success: function (data) {
       // data.users.name and real_name
       data.users.forEach(function (val) {

--- a/js/needinfo.js
+++ b/js/needinfo.js
@@ -263,9 +263,6 @@ function loadPage() {
     /////////////////////////////////////////////////////////
 
     let url = NeedInfoConfig.bugzilla_search_url;
-    if (NeedInfoConfig.api_key.length) {
-      url += "api_key=" + NeedInfoConfig.api_key + "&";
-    }
     url += NeedInfoConfig.fields_query.replace("{id}", id);
 
     // if requested, max lifetime date
@@ -298,9 +295,6 @@ function loadPage() {
     // to the current version tags.
 
     url = NeedInfoConfig.bugzilla_search_url;
-    if (NeedInfoConfig.api_key.length) {
-      url += "api_key=" + NeedInfoConfig.api_key + "&";
-    }
     url += NeedInfoConfig.fields_query.replace("{id}", id);
 
     // if requested, max lifetime date
@@ -343,9 +337,6 @@ function loadPage() {
     /////////////////////////////////////////////////////////
 
     url = NeedInfoConfig.bugzilla_search_url;
-    if (NeedInfoConfig.api_key.length) {
-      url += "api_key=" + NeedInfoConfig.api_key + "&";
-    }
     url += NeedInfoConfig.fields_query.replace("{id}", id);
 
     // if requested, max lifetime date
@@ -373,9 +364,6 @@ function loadPage() {
     /////////////////////////////////////////////////////////
 
     url = NeedInfoConfig.bugzilla_search_url;
-    if (NeedInfoConfig.api_key.length) {
-      url += "api_key=" + NeedInfoConfig.api_key + "&";
-    }
     url += NeedInfoConfig.fields_query.replace("{id}", id);
 
     // if requested, max lifetime date
@@ -396,9 +384,6 @@ function loadPage() {
     /////////////////////////////////////////////////////////
 
     url = NeedInfoConfig.bugzilla_search_url;
-    if (NeedInfoConfig.api_key.length) {
-      url += "api_key=" + NeedInfoConfig.api_key + "&";
-    }
     url += NeedInfoConfig.fields_query.replace("{id}", id);
 
     // if requested, max lifetime date
@@ -444,6 +429,7 @@ function errorMsg(text) {
 function retrieveInfoFor(url, id, elementIndex, developer, userQuery) {
   $.ajax({
     url: url,
+    headers: {"X-Bugzilla-api-key": `${NeedInfoConfig.api_key}`},
     success: function (data) {
       displayCountFor(id, elementIndex, developer, url, userQuery, data);
     }
@@ -555,12 +541,10 @@ function queryAccount() {
 function submitUserSearch(value) {
   let url = NeedInfoConfig.bugzilla_user_url;
   url = url.replace('{value}', value);
-  if (NeedInfoConfig.api_key.length) {
-    url += "&api_key=" + NeedInfoConfig.api_key;
-  }
   $('#autofill-user-search').empty();
   $.ajax({
     url: url,
+    headers: {"X-Bugzilla-api-key": `${NeedInfoConfig.api_key}`},
     success: function (data) {
       // data.users.name and real_name
       data.users.forEach(function (val) {


### PR DESCRIPTION
This fixes issue #12  by moving the  `api_key` from the deprecated URL query parameter (which will get logged in lots of places) to an X-Bugzilla- header.